### PR TITLE
GCI-59 | Connect controller to service layer

### DIFF
--- a/app/connectors/DesConnector.scala
+++ b/app/connectors/DesConnector.scala
@@ -48,9 +48,9 @@ class DesConnector @Inject()(httpClient: HttpClient,
 
   def header: HeaderCarrier = HeaderCarrier(extraHeaders = commonHeaderValues)
 
-  def retrieveCitizenIncome(nino: Nino, matchingFields: RequestDetails)(implicit hc: HeaderCarrier): Future[DesResponse] = {
+  def retrieveCitizenIncome(nino: Nino, requestDetails: RequestDetails)(implicit hc: HeaderCarrier): Future[DesResponse] = {
     val postUrl = desPathUrl(nino)
-    httpClient.POST(postUrl, matchingFields).flatMap {
+    httpClient.POST(postUrl, requestDetails).flatMap {
     httpResponse =>
       httpResponse.status match {
         case Status.OK => Future.successful(parseDesResponse[DesSuccessResponse](httpResponse))

--- a/app/connectors/DesConnector.scala
+++ b/app/connectors/DesConnector.scala
@@ -19,7 +19,7 @@ package connectors
 
 import com.google.inject.{Inject, Singleton}
 import config.DesConfig
-import models.MatchingDetails
+import models.RequestDetails
 import models.response.{DesFailureResponse, DesResponse, DesSuccessResponse, DesUnexpectedResponse}
 import play.api.Logger
 import play.api.http.Status
@@ -48,7 +48,7 @@ class DesConnector @Inject()(httpClient: HttpClient,
 
   def header: HeaderCarrier = HeaderCarrier(extraHeaders = commonHeaderValues)
 
-  def retrieveCitizenIncome(nino: Nino, matchingFields: MatchingDetails)(implicit hc: HeaderCarrier): Future[DesResponse] = {
+  def retrieveCitizenIncome(nino: Nino, matchingFields: RequestDetails)(implicit hc: HeaderCarrier): Future[DesResponse] = {
     val postUrl = desPathUrl(nino)
     httpClient.POST(postUrl, matchingFields).flatMap {
     httpResponse =>

--- a/app/controllers/RealTimeIncomeInformationController.scala
+++ b/app/controllers/RealTimeIncomeInformationController.scala
@@ -17,10 +17,7 @@
 package controllers
 
 import com.google.inject.{Inject, Singleton}
-import connectors.DesConnector
 import models.RequestDetails
-import models.response.{DesFailureResponse, DesSuccessResponse, DesUnexpectedResponse}
-import play.api.libs.json.Json
 import play.api.mvc._
 import services.RealTimeIncomeInformationService
 import uk.gov.hmrc.domain.Nino

--- a/app/controllers/RealTimeIncomeInformationController.scala
+++ b/app/controllers/RealTimeIncomeInformationController.scala
@@ -22,21 +22,20 @@ import models.RequestDetails
 import models.response.{DesFailureResponse, DesSuccessResponse, DesUnexpectedResponse}
 import play.api.libs.json.Json
 import play.api.mvc._
+import services.RealTimeIncomeInformationService
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 @Singleton
-class RealTimeIncomeInformationController @Inject()(val desConnector: DesConnector) extends BaseController {
+class RealTimeIncomeInformationController @Inject()(val rtiiService: RealTimeIncomeInformationService) extends BaseController {
 
   def retrieveCitizenIncome(nino: String)= Action.async(parse.json) {
     implicit request =>
       withJsonBody[RequestDetails] { body =>
-          desConnector.retrieveCitizenIncome (Nino(nino), body) map {
-            case desSuccess: DesSuccessResponse => Ok(Json.toJson(desSuccess))
-            case desFailure: DesFailureResponse => BadRequest(Json.toJson(desFailure))
-            case _: DesUnexpectedResponse => InternalServerError
+          rtiiService.retrieveCitizenIncome (Nino(nino), body) map {
+            Ok(_)
           }
       }
   }

--- a/app/controllers/RealTimeIncomeInformationController.scala
+++ b/app/controllers/RealTimeIncomeInformationController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import com.google.inject.{Inject, Singleton}
 import connectors.DesConnector
-import models.MatchingDetails
+import models.RequestDetails
 import models.response.{DesFailureResponse, DesSuccessResponse, DesUnexpectedResponse}
 import play.api.libs.json.Json
 import play.api.mvc._
@@ -32,7 +32,7 @@ class RealTimeIncomeInformationController @Inject()(val desConnector: DesConnect
 
   def retrieveCitizenIncome(nino: String)= Action.async(parse.json) {
     implicit request =>
-      withJsonBody[MatchingDetails] { body =>
+      withJsonBody[RequestDetails] { body =>
           desConnector.retrieveCitizenIncome (Nino(nino), body) map {
             case desSuccess: DesSuccessResponse => Ok(Json.toJson(desSuccess))
             case desFailure: DesFailureResponse => BadRequest(Json.toJson(desFailure))

--- a/app/models/RequestDetails.scala
+++ b/app/models/RequestDetails.scala
@@ -18,7 +18,7 @@ package models
 
 import play.api.libs.json.Json
 
-case class MatchingDetails(
+case class RequestDetails(
   fromDate: String,
   toDate: String,
   surname: String,
@@ -26,9 +26,10 @@ case class MatchingDetails(
   middleName: Option[String],
   gender: Option[String],
   initials: Option[String],
-  dateOfBirth: Option[String]
+  dateOfBirth: Option[String],
+  filterFields: List[String]
 )
 
-object MatchingDetails {
-  implicit val formats = Json.format[MatchingDetails]
+object RequestDetails {
+  implicit val formats = Json.format[RequestDetails]
 }

--- a/app/models/response/DesResponse.scala
+++ b/app/models/response/DesResponse.scala
@@ -29,6 +29,8 @@ object DesResponse {
 
   implicit val desSuccessFormats = Json.format[DesSuccessResponse]
 
+  implicit val desUnexpectedFormats = Json.format[DesUnexpectedResponse]
+
   implicit val desSuccessReads: Reads[DesSuccessResponse] = (
     (JsPath \ "matchPattern").read[Int] and
     (JsPath \ "taxYears").read[List[JsValue]]

--- a/app/services/RealTimeIncomeInformationService.scala
+++ b/app/services/RealTimeIncomeInformationService.scala
@@ -30,8 +30,6 @@ import scala.concurrent.Future
 @Singleton
 class RealTimeIncomeInformationService @Inject()(val desConnector: DesConnector) {
 
-  private implicit val hc = HeaderCarrier()
-
   def pickOneValue(key: String, taxYear: JsValue): (String, JsValue) = {
     taxYear.transform((__ \\ key).json.pick[JsValue]).asOpt match {
       case Some(x) => key -> x
@@ -46,11 +44,11 @@ class RealTimeIncomeInformationService @Inject()(val desConnector: DesConnector)
           key => pickOneValue(key, taxYear)).toMap)))
   }
 
-  def retrieveCitizenIncome(nino: Nino, matchingDetails: RequestDetails) : Future[JsValue] = {
-    desConnector.retrieveCitizenIncome(nino, matchingDetails)(hc) map {
-      case desSuccess: DesSuccessResponse => pickAll(matchingDetails.filterFields, desSuccess)
+  def retrieveCitizenIncome(nino: Nino, requestDetails: RequestDetails)(implicit hc: HeaderCarrier) : Future[JsValue] = {
+    desConnector.retrieveCitizenIncome(nino, requestDetails)(hc) map {
+      case desSuccess: DesSuccessResponse => pickAll(requestDetails.filterFields, desSuccess)
       case desFailure: DesFailureResponse => Json.toJson(desFailure)
-      case desUnexpected :DesUnexpectedResponse => Json.toJson(desUnexpected)
+      case desUnexpected: DesUnexpectedResponse => Json.toJson(desUnexpected)
     }
   }
 }

--- a/app/services/RealTimeIncomeInformationService.scala
+++ b/app/services/RealTimeIncomeInformationService.scala
@@ -19,12 +19,12 @@ package services
 import com.google.inject.{Inject, Singleton}
 import connectors.DesConnector
 import models.RequestDetails
-import models.response.{DesFailureResponse, DesSuccessResponse}
+import models.response.{DesFailureResponse, DesSuccessResponse, DesUnexpectedResponse}
 import play.api.libs.json.{JsValue, Json, _}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
-import scala.concurrent.ExecutionContext.Implicits.global
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 @Singleton
@@ -47,9 +47,10 @@ class RealTimeIncomeInformationService @Inject()(val desConnector: DesConnector)
   }
 
   def retrieveCitizenIncome(nino: Nino, matchingDetails: RequestDetails) : Future[JsValue] = {
-    desConnector.retrieveCitizenIncome(nino, matchingDetails)(hc) map(x => x match {
-      case desSuccess:DesSuccessResponse => pickAll(matchingDetails.filterFields, desSuccess)
-      case desFailure:DesFailureResponse => Json.toJson(desFailure)
-  })
+    desConnector.retrieveCitizenIncome(nino, matchingDetails)(hc) map {
+      case desSuccess: DesSuccessResponse => pickAll(matchingDetails.filterFields, desSuccess)
+      case desFailure: DesFailureResponse => Json.toJson(desFailure)
+      case desUnexpected :DesUnexpectedResponse => Json.toJson(desUnexpected)
+    }
   }
 }

--- a/conf/resources/example-request.json
+++ b/conf/resources/example-request.json
@@ -5,5 +5,6 @@
   "firstName": "John",
   "gender": "M",
   "initials": "J B",
-  "dateOfBirth": "2000-03-29"
+  "dateOfBirth": "2000-03-29",
+  "filterFields": ["surname", "nationalInsuranceNumber"]
 }

--- a/test/DesConnectorSpec.scala
+++ b/test/DesConnectorSpec.scala
@@ -19,7 +19,7 @@ import java.util.UUID
 import com.github.tomakehurst.wiremock.client.WireMock._
 import config.DesConfig
 import connectors.DesConnector
-import models.MatchingDetails
+import models.RequestDetails
 import models.response.{DesFailureResponse, DesSuccessResponse, DesUnexpectedResponse}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.mockito.MockitoSugar
@@ -82,7 +82,7 @@ class DesConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures with
             )
         )
 
-        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[MatchingDetails])) {
+        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[RequestDetails])) {
           result => result mustBe expectedResponse
         }
 
@@ -104,7 +104,7 @@ class DesConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures with
             )
         )
 
-        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[MatchingDetails])) {
+        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[RequestDetails])) {
           result => result mustBe expectedResponse
         }
       }
@@ -122,7 +122,7 @@ class DesConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures with
             )
         )
 
-        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[MatchingDetails])) {
+        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[RequestDetails])) {
           result => result mustBe expectedResponse
         }
       }
@@ -140,7 +140,7 @@ class DesConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures with
             )
         )
 
-        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[MatchingDetails])) {
+        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[RequestDetails])) {
           result => result mustBe expectedResponse
         }
       }
@@ -158,7 +158,7 @@ class DesConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures with
             )
         )
 
-        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[MatchingDetails])) {
+        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[RequestDetails])) {
           result => result mustBe expectedResponse
         }
 
@@ -177,7 +177,7 @@ class DesConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures with
             )
         )
 
-        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[MatchingDetails])) {
+        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[RequestDetails])) {
           result => result mustBe expectedResponse
         }
 
@@ -196,7 +196,7 @@ class DesConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures with
             )
         )
 
-        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[MatchingDetails])) {
+        whenReady(connector.retrieveCitizenIncome(nino, exampleRequest.as[RequestDetails])) {
           result => result mustBe response
         }
       }

--- a/test/RealTimeIncomeInformationControllerSpec.scala
+++ b/test/RealTimeIncomeInformationControllerSpec.scala
@@ -25,6 +25,7 @@ import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
 import play.api.test.Helpers.{status, _}
 import play.api.test.{FakeHeaders, FakeRequest}
+import services.RealTimeIncomeInformationService
 import uk.gov.hmrc.domain.{Generator, Nino}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.WireMockHelper
@@ -35,7 +36,7 @@ class RealTimeIncomeInformationControllerSpec extends PlaySpec with MockitoSugar
 
   override protected def portConfigKey: String = "microservice.services.des-hod.port"
 
-  protected lazy val connector: DesConnector = injector.instanceOf[DesConnector]
+  protected lazy val service: RealTimeIncomeInformationService = injector.instanceOf[RealTimeIncomeInformationService]
   protected lazy val controller: RealTimeIncomeInformationController = injector.instanceOf[RealTimeIncomeInformationController]
 
   "RealTimeIncomeInformationController" should {
@@ -52,7 +53,7 @@ class RealTimeIncomeInformationControllerSpec extends PlaySpec with MockitoSugar
             )
         )
 
-        val sut = createSUT(connector)
+        val sut = createSUT(service)
         val result = sut.retrieveCitizenIncome(nino)(fakeRequest)
         status(result) mustBe 200
       }
@@ -60,8 +61,8 @@ class RealTimeIncomeInformationControllerSpec extends PlaySpec with MockitoSugar
 
   }
 
-  def createSUT(desConnector: DesConnector) =
-    new RealTimeIncomeInformationController(desConnector)
+  def createSUT(rtiiService: RealTimeIncomeInformationService) =
+    new RealTimeIncomeInformationController(rtiiService)
 
   private implicit val hc = HeaderCarrier()
 

--- a/test/RealTimeIncomeInformationServiceSpec.scala
+++ b/test/RealTimeIncomeInformationServiceSpec.scala
@@ -14,17 +14,28 @@
  * limitations under the License.
  */
 
-import models.response.DesSuccessResponse
+import connectors.DesConnector
+import models.RequestDetails
+import models.response.{DesFailureResponse, DesSuccessResponse}
 import org.scalatest.MustMatchers
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json._
 import services.RealTimeIncomeInformationService
+import org.mockito.Matchers
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.concurrent.ScalaFutures
+import uk.gov.hmrc.domain.Nino
+import utils.WireMockHelper
 
-class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers with BaseSpec {
+import scala.concurrent.Future
+
+class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers with BaseSpec with MockitoSugar with ScalaFutures {
 
   "RealTimeIncomeInformationService" when {
 
-    val service = new RealTimeIncomeInformationService
+    def service(desConnector: DesConnector) = new RealTimeIncomeInformationService(desConnector)
 
     val taxYear = Json.parse("""
                                      |    {
@@ -61,12 +72,12 @@ class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers wi
     "pickOneValue is called" must {
 
       "return the corresponding value if the requested key is present in the given DesSuccessResponse object" in {
-        val result = service.pickOneValue("surname", taxYear)
+        val result = service(mock[DesConnector]).pickOneValue("surname", taxYear)
         result mustBe "surname" -> JsString("Surname")
       }
 
       "return a value of 'undefined' if the requested key is not present in the given DesSuccessResponse object" in {
-        val result = service.pickOneValue("test", taxYear)
+        val result = service(mock[DesConnector]).pickOneValue("test", taxYear)
         result mustBe "test" -> JsString("undefined")
       }
 
@@ -77,7 +88,7 @@ class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers wi
       "when a single tax year is requested" must {
 
         "return all requested values when all keys are present" in {
-          val result = service.pickAll(List("surname", "nationalInsuranceNumber"), desResponseWithOneTaxYear)
+          val result = service(mock[DesConnector]).pickAll(List("surname", "nationalInsuranceNumber"), desResponseWithOneTaxYear)
 
           result mustBe Json.parse(
             """
@@ -92,7 +103,7 @@ class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers wi
         }
 
         "return all requested values plus an 'undefined' when all keys except one are present" in {
-          val result = service.pickAll(List("surname", "nationalInsuranceNumber", "test"), desResponseWithOneTaxYear)
+          val result = service(mock[DesConnector]).pickAll(List("surname", "nationalInsuranceNumber", "test"), desResponseWithOneTaxYear)
 
           result mustBe Json.parse(
             """
@@ -128,7 +139,7 @@ class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers wi
               |}
             """.stripMargin)
 
-          val result = service.pickAll(List("surname", "nationalInsuranceNumber"), desResponseWithTwoTaxYears)
+          val result = service(mock[DesConnector]).pickAll(List("surname", "nationalInsuranceNumber"), desResponseWithTwoTaxYears)
 
           result mustBe expectedJson
         }
@@ -136,7 +147,47 @@ class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers wi
       }
 
     }
+        "retrieve citizen income is called" when{
 
+          "given a DES success response" must {
+
+            "retrieve and filter data" in {
+
+              val matchingDetails = RequestDetails("2016-12-31", "2017-12-31", "Smith", None, None, None, None, None, List("surname", "nationalInsuranceNumber"))
+              val mockDesConnector = mock[DesConnector]
+
+              when(mockDesConnector.retrieveCitizenIncome(any(), any())(any())).thenReturn(Future.successful(DesSuccessResponse(1, List(taxYear))))
+
+              val expectedJson = Json.parse(
+                """
+                  |{
+                  |"taxYears" : [
+                  |{
+                  |"surname": "Surname",
+                  |"nationalInsuranceNumber":"AB123456C"
+                  |}
+                  |]
+                  |}
+                """.stripMargin)
+
+              whenReady(service(mockDesConnector).retrieveCitizenIncome(Nino("AB123456C"), matchingDetails)) {
+                result => result mustBe expectedJson
+              }
+            }
+          }
+
+          "given a DES failure response return an appropriate error message" in {
+
+            val matchingDetails = RequestDetails("2016-12-31", "2017-12-31", "Smith", None, None, None, None, None, List("surname", "nationalInsuranceNumber"))
+            val mockDesConnector = mock[DesConnector]
+
+            when(mockDesConnector.retrieveCitizenIncome(any(), any())(any())).thenReturn(Future.successful(DesFailureResponse("INVALID_NINO", "Submission has not passed validation. Invalid parameter nino.")))
+
+            whenReady(service(mockDesConnector).retrieveCitizenIncome(Nino("AB123456C"), matchingDetails)) {
+              result => result mustBe invalidNinoJson
+            }
+          }
+        }
   }
 
 }

--- a/test/RealTimeIncomeInformationServiceSpec.scala
+++ b/test/RealTimeIncomeInformationServiceSpec.scala
@@ -17,21 +17,22 @@
 import connectors.DesConnector
 import models.RequestDetails
 import models.response.{DesFailureResponse, DesSuccessResponse}
+import org.mockito.Matchers._
+import org.mockito.Mockito._
 import org.scalatest.MustMatchers
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json._
 import services.RealTimeIncomeInformationService
-import org.mockito.Matchers
-import org.mockito.Matchers._
-import org.mockito.Mockito._
-import org.scalatest.concurrent.ScalaFutures
 import uk.gov.hmrc.domain.Nino
-import utils.WireMockHelper
+import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
 
 class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers with BaseSpec with MockitoSugar with ScalaFutures {
+
+  private implicit val hc = HeaderCarrier()
 
   "RealTimeIncomeInformationService" when {
 
@@ -153,7 +154,7 @@ class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers wi
 
             "retrieve and filter data" in {
 
-              val matchingDetails = RequestDetails("2016-12-31", "2017-12-31", "Smith", None, None, None, None, None, List("surname", "nationalInsuranceNumber"))
+              val requestDetails = RequestDetails("2016-12-31", "2017-12-31", "Smith", None, None, None, None, None, List("surname", "nationalInsuranceNumber"))
               val mockDesConnector = mock[DesConnector]
 
               when(mockDesConnector.retrieveCitizenIncome(any(), any())(any())).thenReturn(Future.successful(DesSuccessResponse(1, List(taxYear))))
@@ -170,7 +171,7 @@ class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers wi
                   |}
                 """.stripMargin)
 
-              whenReady(service(mockDesConnector).retrieveCitizenIncome(Nino("AB123456C"), matchingDetails)) {
+              whenReady(service(mockDesConnector).retrieveCitizenIncome(Nino("AB123456C"), requestDetails)) {
                 result => result mustBe expectedJson
               }
             }


### PR DESCRIPTION
- Controller now calls the service layer instead of calling the connector directly
- Refactored `MatchingDetails` model to `RequestDetails` including new `filterFields` property