### PR TITLE
GCI-81 | Handle array of error responses from DES API

### DIFF
--- a/app/Constants.scala
+++ b/app/Constants.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app
+
+object Constants {
+
+  val errorCodeNotFoundNino = "NOT_FOUND_NINO"
+  val errorCodeNotFound = "NOT_FOUND"
+  val errorCodeInvalidCorrelation = "INVALID_CORRELATIONID"
+  val errorCodeInvalidDateRange = "INVALID_DATE_RANGE"
+  val errorCodeInvalidDatesEqual = "INVALID_DATES_EQUAL"
+  val errorCodeInvalidPayload = "INVALID_PAYLOAD"
+  val errorCodeServerError = "SERVER_ERROR"
+  val errorCodeServiceUnavailable = "SERVICE_UNAVAILABLE"
+
+}

--- a/app/connectors/DesConnector.scala
+++ b/app/connectors/DesConnector.scala
@@ -70,13 +70,13 @@ class DesConnector @Inject()(httpClient: HttpClient,
         }
 
         Try(res.json.as[DesSingleFailureResponse]) match {
-          case Success(data) => Logger.info(s"DesFailureResponse from DES: $data")
+          case Success(data) => Logger.info(s"DesSingleFailureResponse from DES: $data")
             data
           case Failure(_) => Try(res.json.as[DesMultipleFailureResponse]) match {
             case Success(multipleFailures) => Logger.info(s"DesMultipleFailureResponse from DES: $multipleFailures")
               multipleFailures
             case Failure(unexpected) =>
-              Logger.error(s"Error from DES (parsing as DesFailureResponse): ${unexpected.getMessage}")
+              Logger.error(s"Error from DES (unable to parse as DesFailureResponse): ${unexpected.getMessage}")
               DesUnexpectedResponse()
           }
         }

--- a/app/connectors/DesConnector.scala
+++ b/app/connectors/DesConnector.scala
@@ -20,7 +20,7 @@ package connectors
 import com.google.inject.{Inject, Singleton}
 import config.DesConfig
 import models.RequestDetails
-import models.response.{DesFailureResponse, DesResponse, DesSuccessResponse, DesUnexpectedResponse}
+import models.response._
 import play.api.Logger
 import play.api.http.Status
 import play.api.libs.json.Reads
@@ -54,7 +54,7 @@ class DesConnector @Inject()(httpClient: HttpClient,
     httpResponse =>
       httpResponse.status match {
         case Status.OK => Future.successful(parseDesResponse[DesSuccessResponse](httpResponse))
-        case _ => Future.successful(parseDesResponse[DesFailureResponse](httpResponse))
+        case _ => Future.successful(parseDesResponse[DesSingleFailureResponse](httpResponse))
       }
     }
   }
@@ -69,11 +69,16 @@ class DesConnector @Inject()(httpClient: HttpClient,
           Logger.error(s"Error from DES (parsing as DesResponse): ${er.getMessage}")
         }
 
-        Try(res.json.as[DesFailureResponse]) match {
+        Try(res.json.as[DesSingleFailureResponse]) match {
           case Success(data) => Logger.info(s"DesFailureResponse from DES: $data")
             data
-          case Failure(ex) => Logger.error(s"Error from DES (parsing as DesFailureResponse): ${ex.getMessage}")
-            DesUnexpectedResponse()
+          case Failure(_) => Try(res.json.as[DesMultipleFailureResponse]) match {
+            case Success(multipleFailures) => Logger.info(s"DesMultipleFailureResponse from DES: $multipleFailures")
+              multipleFailures
+            case Failure(unexpected) =>
+              Logger.error(s"Error from DES (parsing as DesFailureResponse): ${unexpected.getMessage}")
+              DesUnexpectedResponse()
+          }
         }
     }
   }

--- a/app/controllers/RealTimeIncomeInformationController.scala
+++ b/app/controllers/RealTimeIncomeInformationController.scala
@@ -16,34 +16,51 @@
 
 package controllers
 
+import app.Constants
 import com.google.inject.{Inject, Singleton}
 import models.RequestDetails
 import models.response.{DesFilteredSuccessResponse, DesMultipleFailureResponse, DesSingleFailureResponse, DesUnexpectedResponse}
-import play.api.libs.json.Json
+import play.api.Logger
+import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
 import services.RealTimeIncomeInformationService
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success, Try}
 
 @Singleton
 class RealTimeIncomeInformationController @Inject()(val rtiiService: RealTimeIncomeInformationService) extends BaseController {
 
-  def retrieveCitizenIncome(nino: String)= Action.async(parse.json) {
+  def retrieveCitizenIncome(nino: String): Action[JsValue] = Action.async(parse.json) {
     implicit request =>
       withJsonBody[RequestDetails] { body =>
           rtiiService.retrieveCitizenIncome (Nino(nino), body) map {
             case filteredResponse: DesFilteredSuccessResponse => Ok(Json.toJson(filteredResponse))
-            case singleFailureResponse@ DesSingleFailureResponse(code, _) =>
-              if (code == "NOT_FOUND_NINO" || code == "NOT_FOUND")
-                NotFound(Json.toJson(singleFailureResponse)) else if (code == "SERVER_ERROR")
-                InternalServerError(Json.toJson(singleFailureResponse)) else if (code == "SERVICE_UNAVAILABLE")
-                ServiceUnavailable(Json.toJson(singleFailureResponse)) else
-                BadRequest(Json.toJson(singleFailureResponse))
+            case singleFailureResponse: DesSingleFailureResponse => failureResponseToResult(singleFailureResponse)
             case multipleFailureResponse: DesMultipleFailureResponse => BadRequest(Json.toJson(multipleFailureResponse))
             case unexpectedResponse: DesUnexpectedResponse => InternalServerError(Json.toJson(unexpectedResponse))
           }
       }
   }
+
+  private def failureResponseToResult(r: DesSingleFailureResponse): Result = {
+    val results = Map(
+      Constants.errorCodeServerError -> InternalServerError(Json.toJson(r)),
+      Constants.errorCodeNotFoundNino -> NotFound(Json.toJson(r)),
+      Constants.errorCodeNotFound -> NotFound(Json.toJson(r)),
+      Constants.errorCodeServiceUnavailable -> ServiceUnavailable(Json.toJson(r)),
+      Constants.errorCodeInvalidCorrelation -> BadRequest(Json.toJson(r)),
+      Constants.errorCodeInvalidDateRange -> BadRequest(Json.toJson(r)),
+      Constants.errorCodeInvalidDatesEqual -> BadRequest(Json.toJson(r)),
+      Constants.errorCodeInvalidPayload -> BadRequest(Json.toJson(r)))
+
+    Try(results(r.code)) match {
+      case Success(result) => result
+      case Failure(_) => Logger.info(s"Error from DES does not match schema: $r")
+        InternalServerError(Json.toJson(r))
+    }
+  }
+
 }

--- a/app/services/RealTimeIncomeInformationService.scala
+++ b/app/services/RealTimeIncomeInformationService.scala
@@ -19,7 +19,7 @@ package services
 import com.google.inject.{Inject, Singleton}
 import connectors.DesConnector
 import models.RequestDetails
-import models.response.{DesFailureResponse, DesSuccessResponse, DesUnexpectedResponse}
+import models.response._
 import play.api.libs.json.{JsValue, Json, _}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
@@ -44,11 +44,12 @@ class RealTimeIncomeInformationService @Inject()(val desConnector: DesConnector)
           key => pickOneValue(key, taxYear)).toMap)))
   }
 
-  def retrieveCitizenIncome(nino: Nino, requestDetails: RequestDetails)(implicit hc: HeaderCarrier) : Future[JsValue] = {
+  def retrieveCitizenIncome(nino: Nino, requestDetails: RequestDetails)(implicit hc: HeaderCarrier) : Future[DesResponse] = {
     desConnector.retrieveCitizenIncome(nino, requestDetails)(hc) map {
-      case desSuccess: DesSuccessResponse => pickAll(requestDetails.filterFields, desSuccess)
-      case desFailure: DesFailureResponse => Json.toJson(desFailure)
-      case desUnexpected: DesUnexpectedResponse => Json.toJson(desUnexpected)
+      case desSuccess: DesSuccessResponse => DesFilteredSuccessResponse(pickAll(requestDetails.filterFields, desSuccess))
+      case desSingleFailure: DesSingleFailureResponse => desSingleFailure
+      case desMultipleFailure: DesMultipleFailureResponse => desMultipleFailure
+      case desUnexpected: DesUnexpectedResponse => desUnexpected
     }
   }
 }

--- a/app/services/RealTimeIncomeInformationService.scala
+++ b/app/services/RealTimeIncomeInformationService.scala
@@ -47,9 +47,7 @@ class RealTimeIncomeInformationService @Inject()(val desConnector: DesConnector)
   def retrieveCitizenIncome(nino: Nino, requestDetails: RequestDetails)(implicit hc: HeaderCarrier) : Future[DesResponse] = {
     desConnector.retrieveCitizenIncome(nino, requestDetails)(hc) map {
       case desSuccess: DesSuccessResponse => DesFilteredSuccessResponse(pickAll(requestDetails.filterFields, desSuccess))
-      case desSingleFailure: DesSingleFailureResponse => desSingleFailure
-      case desMultipleFailure: DesMultipleFailureResponse => desMultipleFailure
-      case desUnexpected: DesUnexpectedResponse => desUnexpected
+      case failure: DesResponse => failure
     }
   }
 }

--- a/conf/resources/400-multiple-errors.json
+++ b/conf/resources/400-multiple-errors.json
@@ -1,0 +1,12 @@
+{
+  "failures": [
+    {
+      "code": "INVALID_NINO",
+      "reason": "Submission has not passed validation. Invalid parameter nino."
+    },
+    {
+      "code": "INVALID_PAYLOAD",
+      "reason": "Submission has not passed validation. Invalid Payload."
+    }
+  ]
+}

--- a/conf/resources/500-internal-server-error.json
+++ b/conf/resources/500-internal-server-error.json
@@ -1,0 +1,4 @@
+{
+  "code": "INTERNAL_SERVER_ERROR",
+  "reason": "Internal Server Error"
+}

--- a/test/BaseSpec.scala
+++ b/test/BaseSpec.scala
@@ -32,6 +32,7 @@ trait BaseSpec {
   val successMatchOneYear = readJson("conf/resources/200-success-matched-one-year.json")
   val successMatchTwoYear = readJson("conf/resources/200-success-matched-two-years.json")
   val exampleRequest = readJson("conf/resources/example-request.json")
+  val multipleErrors = readJson("conf/resources/400-multiple-errors.json")
 
   private def readJson(path: String) = {
     Json.parse(Source.fromFile(path).getLines().mkString)

--- a/test/RealTimeIncomeInformationControllerSpec.scala
+++ b/test/RealTimeIncomeInformationControllerSpec.scala
@@ -169,6 +169,23 @@ class RealTimeIncomeInformationControllerSpec extends PlaySpec with MockitoSugar
         val result = sut.retrieveCitizenIncome(nino)(fakeRequest)
         status(result) mustBe 500
       }
+
+      "DES has given a failure code and reason that do not match schema" in {
+
+        val fakeRequest = FakeRequest(method = "POST", uri = "",
+          headers = FakeHeaders(Seq("Content-type" -> "application/json")), body = Json.toJson(exampleRequest))
+
+        server.stubFor(
+          post(urlEqualTo(s"/individuals/$nino/income"))
+            .willReturn(
+              serverError().withBody("""{ "code": "error", "reason":"error"}""")
+            )
+        )
+
+        val sut = createSUT(service)
+        val result = sut.retrieveCitizenIncome(nino)(fakeRequest)
+        status(result) mustBe 500
+      }
     }
   }
 

--- a/test/RealTimeIncomeInformationServiceSpec.scala
+++ b/test/RealTimeIncomeInformationServiceSpec.scala
@@ -16,7 +16,7 @@
 
 import connectors.DesConnector
 import models.RequestDetails
-import models.response.{DesFailureResponse, DesSuccessResponse}
+import models.response.{DesFilteredSuccessResponse, DesSingleFailureResponse, DesSuccessResponse}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.MustMatchers
@@ -172,7 +172,7 @@ class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers wi
                 """.stripMargin)
 
               whenReady(service(mockDesConnector).retrieveCitizenIncome(Nino("AB123456C"), requestDetails)) {
-                result => result mustBe expectedJson
+                result => result mustBe DesFilteredSuccessResponse(expectedJson)
               }
             }
           }
@@ -182,10 +182,10 @@ class RealTimeIncomeInformationServiceSpec extends PlaySpec with MustMatchers wi
             val matchingDetails = RequestDetails("2016-12-31", "2017-12-31", "Smith", None, None, None, None, None, List("surname", "nationalInsuranceNumber"))
             val mockDesConnector = mock[DesConnector]
 
-            when(mockDesConnector.retrieveCitizenIncome(any(), any())(any())).thenReturn(Future.successful(DesFailureResponse("INVALID_NINO", "Submission has not passed validation. Invalid parameter nino.")))
+            when(mockDesConnector.retrieveCitizenIncome(any(), any())(any())).thenReturn(Future.successful(DesSingleFailureResponse("INVALID_NINO", "Submission has not passed validation. Invalid parameter nino.")))
 
             whenReady(service(mockDesConnector).retrieveCitizenIncome(Nino("AB123456C"), matchingDetails)) {
-              result => result mustBe invalidNinoJson
+              result => result mustBe DesSingleFailureResponse("INVALID_NINO", "Submission has not passed validation. Invalid parameter nino.")
             }
           }
         }


### PR DESCRIPTION
- Split `DesFailureResponse` into `DesSingleFailureResponse` and `DesMultpleFailureResponses`, to handle different structure of errors that DES API might return
- Refactor controller to return appropriate result type