### PR TITLE
GCI-102 | Add additional route for API platform

### DIFF
--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -4,4 +4,6 @@
 
 ->         /real-time-income-information              app.Routes
 
+POST      /individuals/:correlationId/income             @controllers.RealTimeIncomeInformationController.retrieveCitizenIncome(correlationId: String)
+
 GET        /admin/metrics             com.kenshoo.play.metrics.MetricsController.metrics


### PR DESCRIPTION
The API Gateway strips the `real-time-income-information` portion from our requests. As a consequence, requests will attempt to call the route `/individuals/{correlationId}/income`, so this needs to be defined as part of our routes.